### PR TITLE
have sfu-client listen for RTP media to stream to the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+
+# Running the server
+```
+docker buildx build --tag sfu-server -f docker/server/Dockerfile .
+docker run -it --rm -p 8088:8088 --name sfu-server sfu-server
+```
+
+# RTP Client
+The `sfu-client` listens for RTP video and audio streams on UDP ports 5004 and 5006 respectively, which it will stream to the `sfu-server`:
+```
+docker buildx build --tag sfu-client -f docker/client/Dockerfile .
+docker run -it --rm -p 5004:5004/udp -p 5006:5006/udp -e SFU_SERVER=ws://172.17.0.3:8088 --name sfu-client sfu-client
+```
+
+FFMpeg can be used to send test media streams:
+```
+ffmpeg -re -f lavfi -i testsrc=size=640x480:rate=30 -vcodec libvpx -cpu-used 5 -deadline 1 -g 10 -error-resilient 1 -auto-alt-ref 1 -f rtp 'rtp://127.0.0.1:5004?pkt_size=1200'
+ffmpeg -f lavfi -i 'sine=frequency=1000' -c:a libopus -b:a 48000 -sample_fmt s16p -ssrc 1 -payload_type 111 -f rtp -max_delay 0 -application lowdelay 'rtp://127.0.0.1:5006?pkt_size=1200'
+```

--- a/cmd/sfu-client/main.go
+++ b/cmd/sfu-client/main.go
@@ -2,8 +2,16 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"net"
+	"net/url"
+	"os"
 
+	"github.com/pion/rtp"
+	"github.com/pion/rtp/codecs"
+	"github.com/pion/webrtc/v3"
+	"github.com/pion/webrtc/v3/pkg/media/samplebuilder"
 	"github.com/progrium/webrtc-sessions/local"
 	"tractor.dev/toolkit-go/engine"
 )
@@ -14,10 +22,99 @@ func main() {
 
 type Main struct{}
 
-func (m *Main) Serve(ctx context.Context) {
-	peer, err := local.NewPeer("ws://localhost:8088/session")
+func fatal(err error) {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+func (m *Main) Serve(ctx context.Context) {
+	host := os.Getenv("SFU_SERVER")
+	if host == "" {
+		host = "ws://localhost:8088"
+	}
+	hostURL, err := url.JoinPath(host, "session")
+	fatal(err)
+	peer, err := local.NewPeer(hostURL)
+	fatal(err)
+
+	videoTrack, err := webrtc.NewTrackLocalStaticSample(webrtc.RTPCodecCapability{MimeType: "video/vp8"}, "video", "pion")
+	fatal(err)
+	err = addTrack(ctx, peer, videoTrack)
+	fatal(err)
+
+	audioTrack, err := webrtc.NewTrackLocalStaticSample(webrtc.RTPCodecCapability{MimeType: "audio/opus"}, "audio", "pion")
+	fatal(err)
+	err = addTrack(ctx, peer, audioTrack)
+	fatal(err)
+
+	go rtpToTrack(ctx, videoTrack, &codecs.VP8Packet{}, 90000, 5004)
+	go rtpToTrack(ctx, audioTrack, &codecs.OpusPacket{}, 48000, 5006)
+
 	peer.HandleSignals()
+}
+
+func addTrack(ctx context.Context, peer *local.Peer, track webrtc.TrackLocal) error {
+	sender, err := peer.AddTrack(track)
+	if err != nil {
+		return err
+	}
+	go processRTCP(ctx, sender)
+	return nil
+}
+
+// Read incoming RTCP packets
+// Before these packets are retuned they are processed by interceptors. For things
+// like NACK this needs to be called.
+func processRTCP(ctx context.Context, rtpSender *webrtc.RTPSender) {
+	rtcpBuf := make([]byte, 1500)
+
+	for {
+		if _, _, rtcpErr := rtpSender.Read(rtcpBuf); rtcpErr != nil {
+			return
+		}
+	}
+}
+
+// Listen for incoming packets on a port and write them to a Track
+func rtpToTrack(ctx context.Context, track *webrtc.TrackLocalStaticSample, depacketizer rtp.Depacketizer, sampleRate uint32, port int) {
+	// Open a UDP Listener for RTP Packets on port 5004
+	listener, err := net.ListenUDP("udp", &net.UDPAddr{Port: port})
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err = listener.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	sampleBuffer := samplebuilder.New(10, depacketizer, sampleRate)
+
+	// Read RTP packets forever and send them to the WebRTC Client
+	for {
+		inboundRTPPacket := make([]byte, 1500) // UDP MTU
+		packet := &rtp.Packet{}
+
+		n, _, err := listener.ReadFrom(inboundRTPPacket)
+		if err != nil {
+			panic(fmt.Sprintf("error during read: %s", err))
+		}
+
+		if err = packet.Unmarshal(inboundRTPPacket[:n]); err != nil {
+			panic(err)
+		}
+
+		sampleBuffer.Push(packet)
+		for {
+			sample := sampleBuffer.Pop()
+			if sample == nil {
+				break
+			}
+
+			if writeErr := track.WriteSample(*sample); writeErr != nil {
+				panic(writeErr)
+			}
+		}
+	}
 }

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.21-alpine as builder
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN apk add --no-cache ca-certificates git
+RUN go mod download
+
+COPY . ./
+RUN CGO_ENABLED=0 go build -v -o sfu-client ./cmd/sfu-client
+
+FROM scratch
+
+COPY --from=builder /app/sfu-client /app/sfu-client
+ENTRYPOINT [ "/app/sfu-client" ]

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.21-alpine as builder
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN apk add --no-cache ca-certificates git
+RUN go mod download
+
+COPY . ./
+RUN CGO_ENABLED=0 go build -v -o sfu-server ./cmd/sfu-server
+
+FROM scratch
+
+COPY --from=builder /app/sfu-server /app/sfu-server
+ENTRYPOINT [ "/app/sfu-server" ]

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gorilla/websocket v1.5.1
 	github.com/pion/rtcp v1.2.13
 	github.com/pion/webrtc/v3 v3.2.23
-	tractor.dev/toolkit-go v0.0.0-20231108030452-f76673e11cd3
+	tractor.dev/toolkit-go v0.0.0-20231213181448-28ab3c91533b
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -202,3 +202,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 tractor.dev/toolkit-go v0.0.0-20231108030452-f76673e11cd3 h1:RZ6kq7stc3gPEljEhmbgB7uLQd1xRz2JA68a/HA+6p0=
 tractor.dev/toolkit-go v0.0.0-20231108030452-f76673e11cd3/go.mod h1:gteH4mWzJV+Y5zk6/Q6rPuWeOCFHnr55XPTgYEHuzUo=
+tractor.dev/toolkit-go v0.0.0-20231213181448-28ab3c91533b h1:XGO9YLxKZHwliP2lrlHrZsXJmHxfSMgedPTV4sVDOSQ=
+tractor.dev/toolkit-go v0.0.0-20231213181448-28ab3c91533b/go.mod h1:gteH4mWzJV+Y5zk6/Q6rPuWeOCFHnr55XPTgYEHuzUo=


### PR DESCRIPTION
This updates the `sfu-client` to listen for media streams over RTP and send
those to the server.

Dockerfiles are provided to build and run the client and server.
