### PR TITLE
defer initializing the client session until we have a stream

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -16,31 +16,37 @@
   </body>
   <script type="module">
       
-    const sess = new Session(`ws://${location.host}/session`);
-    sess.onclose = (evt) => console.log("Websocket has closed");
-    sess.onerror = (evt) => console.log("ERROR: " + evt.data);
-    sess.ontrack = ({ streams: [stream], track }) => {
-      if (track.kind === 'audio') {
-        return
-      }
-      console.log("new stream")
-
-      const el = document.createElement(track.kind);
-      el.srcObject = stream;
-      el.autoplay = true;
-      el.controls = true;
-      document.getElementById('remote').appendChild(el)
-
-      stream.onremovetrack = () => {
-        if (el.parentNode) {
-          el.parentNode.removeChild(el)
+    let sess = null;
+    const initSession = () => {
+      sess = new Session(`ws://${location.host}/session`);
+      sess.onclose = (evt) => console.log("Websocket has closed");
+      sess.onerror = (evt) => console.log("ERROR: " + evt.data);
+      sess.ontrack = ({ streams: [stream], track }) => {
+        if (track.kind === 'audio') {
+          return
         }
-      }
+        console.log("new stream")
+
+        const el = document.createElement(track.kind);
+        el.srcObject = stream;
+        el.autoplay = true;
+        el.controls = true;
+        document.getElementById('remote').appendChild(el)
+
+        stream.onremovetrack = () => {
+          if (el.parentNode) {
+            el.parentNode.removeChild(el)
+          }
+        }
+      };
     };
 
     const localMedia = new LocalMedia();
     localMedia.ondevicechange = () => m.redraw();
     localMedia.onstreamchange = (stream) => {
+      if (sess == null) {
+        initSession();
+      }
       sess.setStream(stream);
       document.querySelector("#local").srcObject = stream;
     }


### PR DESCRIPTION
WebRTC expects a connection to have at least one available track.
This is an issue if the first client tries to initialize the connection
before a remote track is available. So we can defer starting the session
until the local track is available.

If needed, we might be able to handle this in the connection logic where we can
start the session, but don't provide an `answer` until there's at least one
track. If we get an `offer` which contains tracks, we can answer immediately, or
we wait and provide an `answer` once we have added a local track.
