### PR TITLE
Add "Share screen" button

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -15,7 +15,6 @@
     <main></main>
   </body>
   <script type="module">
-      
     let sess = null;
     const initSession = () => {
       sess = new Session(`ws://${location.host}/session`);
@@ -53,6 +52,7 @@
 
     m.mount(document.querySelector("#devices"), {
       view: () => m("div", [
+        m("button", {onclick: (e) => localMedia.shareScreen()}, [ "Share screen" ]),
         m("select", {onchange: (e) => localMedia.setVideoSource(e.target.value)}, localMedia.videoDevices.map(device => {
           return m("option", {value: device.deviceId}, device.label)
         })),
@@ -61,6 +61,5 @@
         })),
       ]),
     });
-
   </script>
 </html>

--- a/web/localmedia.js
+++ b/web/localmedia.js
@@ -1,5 +1,3 @@
-
-
 class LocalMedia {
   constructor() {
     this.onstreamchange = (stream) => null;
@@ -24,11 +22,24 @@ class LocalMedia {
     this.updateStream();
   }
 
+  shareScreen() {
+    this.setVideoSource('screen');
+    this.updateStream();
+  }
+
   async updateStream() {
-    this.stream = await navigator.mediaDevices.getUserMedia({
-      audio: {deviceId: this.audioSource ? {exact: this.audioSource} : true},
-      video: {deviceId: this.videoSource ? {exact: this.videoSource} : true}
-    });
+    if (this.videoSource === 'screen') {
+      this.stream = await navigator.mediaDevices.getDisplayMedia({
+        audio: {deviceId: true},
+        video: {deviceId: true},
+        systemAudio: 'include',
+      });
+    } else {
+      this.stream = await navigator.mediaDevices.getUserMedia({
+        audio: {deviceId: this.audioSource ? {exact: this.audioSource} : true},
+        video: {deviceId: this.videoSource ? {exact: this.videoSource} : true}
+      });
+   }
     if (this.onstreamchange) {
       this.onstreamchange(this.stream);
     }
@@ -42,5 +53,4 @@ class LocalMedia {
       this.ondevicechange();
     }
   }
-
 }


### PR DESCRIPTION
Allow sharing the screen or another tab to the WebRTC stream instead of a
camera. We can use this to test out sharing from a tab containing Greenlight or
other audio sources in order to get that into Bridge.

(note: only Chrome directly supports this call, but we can look into other browsers later if this is useful)
