### PR TITLE
push audio into new Track model

### DIFF
--- a/bridge/tracks/tracks.go
+++ b/bridge/tracks/tracks.go
@@ -81,7 +81,19 @@ type Session struct {
 	Tracks []*Track
 }
 
-func (s *Session) NewTrack(start Timestamp, format beep.Format) *Track {
+func NewSession() *Session {
+	return &Session{
+		ID:    newID(),
+		Start: time.Now().UTC(),
+	}
+}
+
+func (s *Session) NewTrack(format beep.Format) *Track {
+	start := time.Now().UTC().Sub(s.Start)
+	return s.NewTrackAt(Timestamp(start), format)
+}
+
+func (s *Session) NewTrackAt(start Timestamp, format beep.Format) *Track {
 	t := &Track{
 		ID:      newID(),
 		Session: s,

--- a/bridge/tracks/tracks_test.go
+++ b/bridge/tracks/tracks_test.go
@@ -115,7 +115,7 @@ func TestSerializeTrack(t *testing.T) {
 
 func TestSerializeSession(t *testing.T) {
 	session := &Session{}
-	track := session.NewTrack(0, beep.Format{
+	track := session.NewTrackAt(0, beep.Format{
 		SampleRate:  beep.SampleRate(48000),
 		NumChannels: 2,
 		Precision:   2,
@@ -165,7 +165,7 @@ func TestAudio(t *testing.T) {
 		Precision:   2,
 	}
 	session := &Session{}
-	track := session.NewTrack(0, format)
+	track := session.NewTrackAt(0, format)
 	gen := audioGenerator(t)
 
 	assert.Equal(t, Timestamp(0), track.End(), "End should start at 0")

--- a/bridge/vad/annotator.go
+++ b/bridge/vad/annotator.go
@@ -79,7 +79,7 @@ func New(config Config) *Annotator {
 }
 
 func (a *Annotator) Annotated(annot tracks.Annotation) {
-	if annot.Type() != "audio" {
+	if annot.Type != "audio" {
 		return
 	}
 	pcm, err := audio.StreamAll(annot.Span().Audio())


### PR DESCRIPTION
Example for pushing audio from the RTP stream into the new Track model.
This doesn't update the consumers, but just shows how we can feed audio data into the Track.