### PR TITLE
Enable continuous streaming from Track.Audio

### DIFF
--- a/bridge/tracks/buffer.go
+++ b/bridge/tracks/buffer.go
@@ -1,0 +1,52 @@
+package tracks
+
+import (
+	"sync"
+
+	"github.com/gopxl/beep"
+)
+
+type continuousBuffer struct {
+	mu    sync.Mutex
+	cond  sync.Cond
+	audio *beep.Buffer
+}
+
+func newContinuousBuffer(format beep.Format) *continuousBuffer {
+	b := &continuousBuffer{audio: beep.NewBuffer(format)}
+	b.cond.L = &b.mu
+	return b
+}
+
+func (b *continuousBuffer) Format() beep.Format {
+	return b.audio.Format()
+}
+
+func (b *continuousBuffer) Append(s beep.Streamer) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.audio.Append(s)
+	b.cond.Broadcast()
+}
+
+func (b *continuousBuffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.audio.Len()
+}
+
+func (b *continuousBuffer) StreamerFrom(start int) beep.Streamer {
+	return beep.Iterate(func() beep.Streamer {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		for {
+			end := b.audio.Len()
+			if end > start {
+				stream := b.audio.Streamer(start, end)
+				start = end
+				return stream
+			}
+			b.cond.Wait()
+		}
+	})
+}

--- a/cmd/minibridge/main.go
+++ b/cmd/minibridge/main.go
@@ -89,33 +89,31 @@ func (m *Main) Serve(ctx context.Context) {
 		ogg, err := oggwriter.New(fmt.Sprintf("track-%s.ogg", track.ID()), uint32(m.format.SampleRate.N(time.Second)), uint16(m.format.NumChannels))
 		fatal(err)
 		defer ogg.Close()
-		rtp := trackstreamer.Tee(track, ogg)
-		s, err := trackstreamer.New(rtp, m.format)
+		rtpStream, err := trackstreamer.New(trackstreamer.Tee(track, ogg), m.format)
 		fatal(err)
 
-		// FIXME the duped streamers still require synchronization when used concurrently
-		s, s2 := beep.Dup(s)
 		go func() {
 			chunkSize := sessTrack.AudioFormat().SampleRate.N(100 * time.Millisecond)
 			for {
 				// since Track.AddAudio expects finite segments, split it into chunks of
 				// a smaller size we can append incrementally
-				chunk := beep.Take(chunkSize, s2)
+				chunk := beep.Take(chunkSize, rtpStream)
 				sessTrack.AddAudio(chunk)
 				fatal(chunk.Err())
 				log.Printf("track %s: %v", sessTrack.ID, time.Duration(sessTrack.End()))
 			}
 		}()
 
+		trackAudio := sessTrack.Audio()
 		detector := vad.New(vad.Config{
 			SampleRate:   m.format.SampleRate.N(time.Second),
 			SampleWindow: 24 * time.Second,
 		})
-		s = effects.Mono(s) // should already be mono, but we can make sure
+		trackAudio = effects.Mono(trackAudio) // should already be mono, but we can make sure
 		// s = &effects.Volume{Streamer: s, Base: 2, Volume: 2}
 		var totSamples int
 		for {
-			pcm, err := Stream32(s, 1024)
+			pcm, err := Stream32(trackAudio, 1024)
 			if err != nil {
 				fatal(err)
 			}

--- a/cmd/minibridge/main.go
+++ b/cmd/minibridge/main.go
@@ -93,6 +93,7 @@ func (m *Main) Serve(ctx context.Context) {
 		s, err := trackstreamer.New(rtp, m.format)
 		fatal(err)
 
+		// FIXME the duped streamers still require synchronization when used concurrently
 		s, s2 := beep.Dup(s)
 		go func() {
 			chunkSize := sessTrack.AudioFormat().SampleRate.N(100 * time.Millisecond)


### PR DESCRIPTION
The previous implementation of `Audio` for a track would return a
snapshot up to the end of the audio available at that time.

This will return a Streamer that continues to receive audio chunks as
they become available.

Span.Audio will still take a limited-size snapshot of the audio for
its specified range.
