### PR TITLE
rename "Annotations" to "Events"

### DIFF
--- a/bridge/cmd/bridge/main.go
+++ b/bridge/cmd/bridge/main.go
@@ -48,7 +48,7 @@ func main() {
 }
 
 type Main struct {
-	Annotators []tracks.Annotator
+	EventHandlers []tracks.Handler
 
 	sessions map[string]*Session
 	format   beep.Format
@@ -137,9 +137,9 @@ func (m *Main) StartSession(sess *Session) {
 
 			// seems like we should be doing this in session
 			span := sessTrack.Span(newstart, sessTrack.End())
-			annot := span.Annotate("audio", nil)
-			for _, antr := range m.Annotators {
-				antr.Annotated(annot)
+			e := span.RecordEvent("audio", nil)
+			for _, antr := range m.EventHandlers {
+				antr.HandleEvent(e)
 			}
 
 			fatal(chunk.Err())

--- a/bridge/services/docker-compose.yaml
+++ b/bridge/services/docker-compose.yaml
@@ -2,18 +2,21 @@ version: '3.6'
 
 services:
   transcriber:
+    platform: "linux/amd64"
     build:
       context: ./transcriber
       dockerfile: Dockerfile
     ports:
       - 8090:8000
   assister:
+    platform: "linux/amd64"
     build:
       context: ./assister
       dockerfile: Dockerfile
     ports:
       - 8091:8080
   translator:
+    platform: "linux/amd64"
     build:
       context: ./translator
       dockerfile: Dockerfile

--- a/bridge/vad/vad.go
+++ b/bridge/vad/vad.go
@@ -68,7 +68,7 @@ func New(config Config) *Annotator {
 	}
 }
 
-func (a *Annotator) Annotated(annot tracks.Annotation) {
+func (a *Annotator) HandleEvent(annot tracks.Event) {
 	if annot.Type != "audio" {
 		return
 	}
@@ -80,7 +80,7 @@ func (a *Annotator) Annotated(annot tracks.Annotation) {
 	win := a.Window(string(annot.Span().Track().ID))
 	start, ok := win.Push(pcm, annot.End)
 	if ok {
-		annot.Span().Span(start, annot.End).Annotate("activity", nil)
+		annot.Span().Span(start, annot.End).RecordEvent("activity", nil)
 	}
 }
 

--- a/cmd/minibridge/transcribe/transcribe.go
+++ b/cmd/minibridge/transcribe/transcribe.go
@@ -34,7 +34,7 @@ type Service struct {
 	mu   sync.Mutex
 }
 
-func (s *Service) Annotated(annot tracks.Annotation) {
+func (s *Service) HandleEvent(annot tracks.Event) {
 	if annot.Type != "activity" {
 		return
 	}
@@ -51,7 +51,7 @@ func (s *Service) Annotated(annot tracks.Annotation) {
 		return
 	}
 
-	annot.Span().Annotate("transcription", Transcription{Words: spans})
+	annot.Span().RecordEvent("transcription", Transcription{Words: spans})
 }
 
 func (s *Service) Transcribe(samples []float32, format beep.Format) []bridge.Span {


### PR DESCRIPTION
Fixes #46. Rename "Annotations" to "Events" to make terminology more clear.

(also force "amd64" platform for docker-compose since some of these don't build
on arm64)
