### PR TITLE
push session updates only when there's a new event

### DIFF
--- a/bridge/tracks/events.go
+++ b/bridge/tracks/events.go
@@ -25,3 +25,7 @@ func (ee *EventEmitter) Emit(e Event) {
 		return true
 	})
 }
+
+type HandlerFunc func(e Event)
+
+func (f HandlerFunc) HandleEvent(e Event) { f(e) }


### PR DESCRIPTION
Use event listeners to handle saving sessions and sending UI updates only when
there are new events.
