### PR TITLE
working UI with transcribe agent

### DIFF
--- a/bridge/audio/wave.go
+++ b/bridge/audio/wave.go
@@ -1,0 +1,108 @@
+package audio
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/go-audio/audio"
+	"github.com/go-audio/wav"
+)
+
+func float32ToInt16(f []float32) []int {
+	int16Data := make([]int, len(f))
+	for i, v := range f {
+		if v < -1 {
+			v = -1
+		} else if v > 1 {
+			v = 1
+		}
+		int16Data[i] = int(v * 32767)
+	}
+	return int16Data
+}
+
+func ToWav(pcmData []float32, sampleRate int) ([]byte, error) {
+
+	int16PCMData := float32ToInt16(pcmData)
+
+	out := NewByteSliceWriteSeeker(1024)
+
+	// Create a new encoder
+	enc := wav.NewEncoder(out, sampleRate, 16, 1, 1)
+
+	// Convert int16 PCM data to an audio.IntBuffer
+	buf := &audio.IntBuffer{Data: int16PCMData, Format: &audio.Format{SampleRate: sampleRate, NumChannels: 1}}
+
+	// Write the buffer to the encoder
+	if err := enc.Write(buf); err != nil {
+		return nil, fmt.Errorf("Error writing to WAV file: %v", err)
+	}
+
+	// Close the encoder to flush any remaining data
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("Error closing WAV file: %v", err)
+	}
+
+	return out.Bytes(), nil
+}
+
+type ByteSliceWriteSeeker struct {
+	data   []byte
+	offset int64
+}
+
+func NewByteSliceWriteSeeker(initialSize int64) *ByteSliceWriteSeeker {
+	return &ByteSliceWriteSeeker{
+		data:   make([]byte, 0, initialSize),
+		offset: 0,
+	}
+}
+
+func (b *ByteSliceWriteSeeker) Write(p []byte) (n int, err error) {
+	// Grow the buffer if necessary
+	endPos := b.offset + int64(len(p))
+	if endPos > int64(cap(b.data)) {
+		// Double it until it's large enough.
+		newSize := cap(b.data)
+		for endPos > int64(newSize) {
+			newSize *= 2
+		}
+		newData := make([]byte, len(b.data), newSize)
+		copy(newData, b.data)
+		b.data = newData
+	}
+	if endPos > int64(len(b.data)) {
+		b.data = b.data[:endPos]
+	}
+
+	// Copy data into the buffer at the current offset
+	copy(b.data[b.offset:], p)
+	b.offset += int64(len(p))
+	return len(p), nil
+}
+
+func (b *ByteSliceWriteSeeker) Seek(offset int64, whence int) (int64, error) {
+	var newOffset int64
+	switch whence {
+	case io.SeekStart:
+		newOffset = offset
+	case io.SeekCurrent:
+		newOffset = b.offset + offset
+	case io.SeekEnd:
+		newOffset = int64(len(b.data)) + offset
+	default:
+		return 0, errors.New("ByteSliceWriteSeeker.Seek: invalid whence")
+	}
+
+	if newOffset < 0 {
+		return 0, errors.New("ByteSliceWriteSeeker.Seek: negative position")
+	}
+
+	b.offset = newOffset
+	return newOffset, nil
+}
+
+func (b *ByteSliceWriteSeeker) Bytes() []byte {
+	return b.data
+}

--- a/bridge/services/transcriber/test.go
+++ b/bridge/services/transcriber/test.go
@@ -18,7 +18,7 @@ func fatal(err error) {
 
 func main() {
 	url := "http://localhost:8090/v1/transcribe"
-	audio, err := os.ReadFile("test.ogg")
+	audio, err := os.ReadFile("test.ogg") // also works with mp3s and wavs
 	fatal(err)
 	request := &TranscriptionRequest{
 		Task:      "transcribe",

--- a/bridge/tracks/events.go
+++ b/bridge/tracks/events.go
@@ -20,7 +20,7 @@ func (ee *EventEmitter) Unlisten(n Handler) {
 func (ee *EventEmitter) Emit(e Event) {
 	ee.m.Range(func(k, v any) bool {
 		if h, ok := v.(Handler); ok {
-			h.HandleEvent(e)
+			go h.HandleEvent(e)
 		}
 		return true
 	})

--- a/bridge/tracks/tracks.go
+++ b/bridge/tracks/tracks.go
@@ -20,6 +20,7 @@ type Span interface {
 	Span(from, to Timestamp) Span
 	Start() Timestamp
 	End() Timestamp
+	Length() time.Duration
 	Audio() beep.Streamer
 	EventTypes() []string
 	Events(typ string) []Event
@@ -44,6 +45,10 @@ type Event struct {
 	EventMeta
 	Data  any
 	track *Track
+}
+
+func (e Event) Track() *Track {
+	return e.track
 }
 
 func (e Event) Span() Span {
@@ -272,6 +277,10 @@ func (t *Track) End() Timestamp {
 	return t.start + Timestamp(dur)
 }
 
+func (t *Track) Length() time.Duration {
+	return time.Duration(t.End() - t.start)
+}
+
 func (t *Track) Track() *Track {
 	return t
 }
@@ -364,6 +373,10 @@ func (s *filteredSpan) Span(from Timestamp, to Timestamp) Span {
 
 func (s *filteredSpan) Start() Timestamp {
 	return s.start
+}
+
+func (s *filteredSpan) Length() time.Duration {
+	return time.Duration(s.end - s.start)
 }
 
 func (s *filteredSpan) Track() *Track {

--- a/bridge/transcribe/transcribe.go
+++ b/bridge/transcribe/transcribe.go
@@ -1,0 +1,115 @@
+package transcribe
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/progrium/webrtc-sessions/bridge/audio"
+	"github.com/progrium/webrtc-sessions/bridge/tracks"
+)
+
+type Agent struct {
+	Endpoint string
+}
+
+func (a *Agent) HandleEvent(annot tracks.Event) {
+	if annot.Type != "activity" {
+		return
+	}
+
+	pcm, err := audio.StreamAll(annot.Span().Audio())
+	if err != nil {
+		log.Println("transcribe:", err)
+		return
+	}
+	b, err := audio.ToWav(pcm, 16000)
+	if err != nil {
+		log.Println("transcribe:", err)
+		return
+	}
+
+	transcription, err := a.Transcribe(&Request{
+		Task:      "transcribe",
+		AudioData: &b,
+	})
+	if err != nil {
+		log.Println("transcribe:", err)
+		return
+	}
+
+	annot.Span().RecordEvent("transcription", transcription)
+}
+
+func (a *Agent) Transcribe(request *Request) (*Transcription, error) {
+	payloadBytes, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.Post(a.Endpoint, "application/json", bytes.NewBuffer(payloadBytes))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusOK {
+		response := &Transcription{}
+		err = json.Unmarshal(body, response)
+		return response, err
+	} else {
+		return nil, fmt.Errorf("transcribe: %s", body)
+	}
+}
+
+type Request struct {
+	AudioData *[]byte `json:"audio_data,omitempty"`
+	Task      string  `json:"task"`
+}
+
+type Transcription struct {
+	TargetLanguage            string              `json:"target_language"`
+	SourceLanguage            string              `json:"source_language"`
+	SourceLanguageProbability float32             `json:"source_language_prob"`
+	Duration                  float32             `json:"duration"`
+	AllLanguageProbs          *map[string]float32 `json:"all_language_probs,omitempty"`
+
+	Segments []Segment `json:"segments"`
+}
+
+func (t Transcription) Text() string {
+	var texts []string
+	for _, seg := range t.Segments {
+		texts = append(texts, seg.Text)
+	}
+	return strings.Join(texts, " ")
+}
+
+type Word struct {
+	Start       float32 `json:"start"`
+	End         float32 `json:"end"`
+	Word        string  `json:"word"`
+	Probability float32 `json:"prob"`
+}
+
+type Segment struct {
+	ID               uint32  `json:"id"`
+	Seek             uint32  `json:"seek"`
+	Start            float32 `json:"start"`
+	End              float32 `json:"end"`
+	Text             string  `json:"text"`
+	Temperature      float32 `json:"temperature"`
+	AvgLogprob       float32 `json:"avg_logprob"`
+	CompressionRatio float32 `json:"compression_ratio"`
+	NoSpeechProb     float32 `json:"no_speech_prob"`
+	Words            []Word  `json:"words"`
+}

--- a/bridge/ui/session.html
+++ b/bridge/ui/session.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/mithril/2.2.3/mithril.min.js" integrity="sha512-veJyRkYTPP9HJBUEq3oqA1uBzxGA+OiiHkcgT4Nm8Ovg9dNKSxf4mxClYVCkujcxIz+reFruwp4OPsXY10U8UA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdn.jsdelivr.net/npm/cbor-js@0.1.0/cbor.min.js"></script>
   <script src="/webrtc/localmedia.js"></script>
   <link rel="stylesheet" href="/ui/session.css" />
 </head>
@@ -38,21 +39,35 @@ localMedia.onstreamchange = (stream) => {
     sess.setStream(stream);
 }
 
-let data = {};
+let viewModel = {};
 let dataWS = new WebSocket(`ws://${location.host}${location.pathname}?data`);
+dataWS.binaryType = 'arraybuffer';
 dataWS.onmessage = e => {
-  data = JSON.parse(e.data);
+  const data = CBOR.decode((new Uint8Array(e.data)).buffer);
+
+  const events = data.Session.Tracks.map(t => t.Events).filter(e => e).flat();
+
+  viewModel = {
+    sessions: data.Sessions,
+    entries: events.filter(e => e.Type === "transcription").map(t => {
+      return {
+        speakerLabel: "user",
+        time: t.Start, // todo: convert
+        text: t.Data.segments.map(s => s.text).join()
+      }
+    })
+  }
   m.redraw()
 }
 
 m.mount(document.body, {
   view: () => [
-    m(Sidebar, {sessions: data.Sessions}), 
-    m("div", {"class":"flex flex-col mx-auto h-screen grow"},
+    m(Sidebar, {sessions: viewModel.sessions}), 
+    m("div", {"class":"flex flex-col mx-auto grow"},
       [
         m(Topbar, {localMedia}),
         m("div", {"class":"grow px-6 mt-4 overflow-auto","id":"session"}, 
-          m(Session, {summary: "Summary", entries: [{text: JSON.stringify(data)}]})
+          m(Session, {summary: "Summary", entries: viewModel.entries})
         )
       ]
     )

--- a/bridge/ui/session.js
+++ b/bridge/ui/session.js
@@ -3,26 +3,17 @@
 export var Session = {
   view: ({attrs}) => {
     return m("div", {"class":"session"}, 
-      m("div", {"class":"entry summary"}, 
-        m("div", {"class":"left"},
-          [
-            m("div", {"class":"line","style":{"background-color":attrs.lineColor}}, 
-              m("div", {"class":"right"},
-                [
-                  m("div", {"class":"date"}, attrs.date),
-                  m("div", {"class":"headline"}, attrs.headline),
-                  m("div", {"class":"summary"}, attrs.summary),
-                  m("div", {"class":"participants"}, 
-                    `Participants: ${(attrs.participants||[]).join(', ')}`
-                  ),
-                  m("div", {"class":"related"}, attrs.related),
-                  m("div", {"class":"stats"}, attrs.statistics)
-                ]
-              )
-            ),
-            ...(attrs.entries||[]).map(entry => m(Entry, entry))
-          ]
-        )
+      m("div", {"class":"mb-4"},
+        [
+          m("div", {"class":"date"}, attrs.date),
+          // m("div", {"class":"summary"}, attrs.summary),
+          m("div", {"class":"participants"}, 
+            `Participants: ${(attrs.participants||[]).join(', ')}`
+          ),
+        ]
+      ),
+      m("div", {"class":""}, 
+        (attrs.entries||[]).map(entry => m(Entry, entry))
       )
     )
   }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ toolchain go1.21.1
 
 require (
 	github.com/fxamacker/cbor/v2 v2.5.0
+	github.com/go-audio/audio v1.0.0
+	github.com/go-audio/wav v1.1.0
 	github.com/gopxl/beep v1.3.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/pion/rtcp v1.2.13
@@ -22,6 +24,7 @@ require (
 require (
 	github.com/ebitengine/oto/v3 v3.1.0 // indirect
 	github.com/ebitengine/purego v0.5.0 // indirect
+	github.com/go-audio/riff v1.0.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,12 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fxamacker/cbor/v2 v2.5.0 h1:oHsG0V/Q6E/wqTS2O1Cozzsy69nqCiguo5Q1a1ADivE=
 github.com/fxamacker/cbor/v2 v2.5.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/go-audio/audio v1.0.0 h1:zS9vebldgbQqktK4H0lUqWrG8P0NxCJVqcj7ZpNnwd4=
+github.com/go-audio/audio v1.0.0/go.mod h1:6uAu0+H2lHkwdGsAY+j2wHPNPpPoeg5AaEFh9FlA+Zs=
+github.com/go-audio/riff v1.0.0 h1:d8iCGbDvox9BfLagY94fBynxSPHO80LmZCaOsmKxokA=
+github.com/go-audio/riff v1.0.0/go.mod h1:l3cQwc85y79NQFCRB7TiPoNiaijp6q8Z0Uv38rVG498=
+github.com/go-audio/wav v1.1.0 h1:jQgLtbqBzY7G+BM8fXF7AHUk1uHUviWS4X39d5rsL2g=
+github.com/go-audio/wav v1.1.0/go.mod h1:mpe9qfwbScEbkd8uybLuIpTgHyrISw/OTuvjUW2iGtE=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=


### PR DESCRIPTION
The old HTML/CSS for the bridge transcript is starting to get annoying to work with so I'm deciding to just chop huge parts of it out and recreate. In this state its not a replacement for substrate bridge, but you can at least see the potential. Only transcribing is wired up, but that's most of how bridge is used.

More specific changes in this PR:
* added `transcribe` agent package. we can call them annotators or agents. event handlers isn't too useful.
* made event handlers run async. they should be safe to run blocking service requests.
* vad was improved, most notably fixing the start time of activity events.
* added `Track` getter for `Event`. was using `event.Span().Track()` before
* added `Length` method to Spans. useful method for a span, who knew
* switched to cbor for ui updates. will probably become duplex at some point anyway

A big time sink today was figuring out how to send data to transcriber service. Again. I forget what it was originally, either raw pcm or wave, and then switched to ogg for compression. But for some reason there are no good paths to encode PCM data into a compressed audio file format. ChatGPT was hallucinating a storm because there are no libraries for it. Mp3 has license issues, and I don't know what's up with ogg, but the only thing that exists is the oggwriter from Pion, which take RTP packets. It really doesn't make sense to keep the RTP packets around anyway and we'd have to slice into them and it just wouldn't be fun. I tried to recreate RTP packets (since they're just Opus packets with a header), but I was not successful. Ultimately since the transcriber service (ie whisper) can auto detect audio files, I just pass it wave files. We can come back to this later. 